### PR TITLE
fix "error: 'cargo-fmt.exe' is not installed"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
       EXE_EXT: ${{ contains(matrix.os, 'windows') && '.exe' || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       with:
         rust-version: 'nightly'
 
+    - name: Install rustfmt (windows only)
+      if: runner.os == 'Windows'
+      run: rustup component add rustfmt
+
     - name: Check targets are installed correctly
       run: rustup target list --installed
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       EXE_EXT: ${{ contains(matrix.os, 'windows') && '.exe' || '' }}
 
     steps:
+    - uses: actions/checkout@v2
     - name: Install LLVM (windows only)
       if: runner.os == 'Windows'
       run: choco install llvm
@@ -21,8 +22,7 @@ jobs:
       with:
         rust-version: 'nightly'
 
-    - name: Install rustfmt (windows only)
-      if: runner.os == 'Windows'
+    - name: Install rustfmt
       run: rustup component add rustfmt
 
     - name: Check targets are installed correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-lastest, macOS-latest, windows-latest]
+        os: [ubuntu-18.04, macOS-latest, windows-latest]
 
     env:
       EXE_EXT: ${{ contains(matrix.os, 'windows') && '.exe' || '' }}


### PR DESCRIPTION
fix to run fmt in CI.

>Run cargo fmt -- --check
error: 'cargo-fmt.exe' is not installed for the toolchain 'nightly-x86_64-pc-windows-msvc'
To install, run `rustup component add rustfmt`

- fix typo: latest